### PR TITLE
Fix: Filter reports by current repository instead of entire organization (#21)

### DIFF
--- a/content.js
+++ b/content.js
@@ -930,8 +930,18 @@ console.log('CronoHub: Content script loaded');
       return;
     }
 
-    // Get organization
-    var org = state.issueData ? state.issueData.owner : window.location.pathname.match(/\/([^/]+)\/([^/]+)/)[1];
+    // Get organization and repository
+    var org, repo;
+    if (state.issueData) {
+      org = state.issueData.owner;
+      repo = state.issueData.repo;
+    } else {
+      var match = window.location.pathname.match(/\/([^/]+)\/([^/]+)/);
+      if (match) {
+        org = match[1];
+        repo = match[2];
+      }
+    }
 
     // Show loading
     btn.disabled = true;
@@ -942,9 +952,9 @@ console.log('CronoHub: Content script loaded');
       ? state.selectedCollaborators.map(function(c) { return c.login; })
       : state.allCollaborators.map(function(c) { return c.login; });
 
-    // Fetch report data for selected users
+    // Fetch report data for selected users (filtered by current repository)
     var fetchPromises = selectedUsernames.map(function(username) {
-      return window.CronoHubReports.fetchUserCommentsInRange(username, org, startDate, endDate, state.config.githubToken)
+      return window.CronoHubReports.fetchUserCommentsInRange(username, org, startDate, endDate, state.config.githubToken, repo)
         .then(function(comments) {
           return {
             username: username,
@@ -999,7 +1009,18 @@ console.log('CronoHub: Content script loaded');
       return;
     }
 
-    var org = state.issueData ? state.issueData.owner : window.location.pathname.match(/\/([^/]+)\/([^/]+)/)[1];
+    // Get organization and repository
+    var org, repo;
+    if (state.issueData) {
+      org = state.issueData.owner;
+      repo = state.issueData.repo;
+    } else {
+      var match = window.location.pathname.match(/\/([^/]+)\/([^/]+)/);
+      if (match) {
+        org = match[1];
+        repo = match[2];
+      }
+    }
 
     btn.disabled = true;
     btn.innerHTML = '<div class="gtt-spinner"></div>Loading...';
@@ -1009,9 +1030,9 @@ console.log('CronoHub: Content script loaded');
       selectedOptions = Array.from(select.options).map(function(option) { return option.value; });
     }
 
-    // Fetch report data for selected users
+    // Fetch report data for selected users (filtered by current repository)
     var fetchPromises = selectedOptions.map(function(username) {
-      return window.CronoHubReports.fetchUserCommentsInRange(username, org, startDate, endDate, state.config.githubToken)
+      return window.CronoHubReports.fetchUserCommentsInRange(username, org, startDate, endDate, state.config.githubToken, repo)
         .then(function(comments) {
           return {
             username: username,


### PR DESCRIPTION
## Summary

Fixes a critical bug where time reports were displaying hours from **all repositories** in the organization instead of filtering by the **current repository** shown in the panel header.

## Problem

When users generated time reports, the extension queried GitHub API using `org:organization` filter, which returns comments from any repository in the organization. This caused confusion because users saw aggregated hours from multiple projects when they expected only hours from the current project.

## Solution

- Modified `fetchUserCommentsInRange()` to accept optional `repo` parameter
- Updated GitHub API search query to use `repo:owner/repo` when repository is provided
- Added repository extraction logic in both report generation functions
- Updated `fetchAllCollaboratorsComments()` to propagate repo parameter

## Technical Changes

### Files Modified

- **content.js** (+35 lines)
  - Added org/repo extraction in `handleGenerateReport()`
  - Added org/repo extraction in `handleGenerateReportWithData()`
  - Pass repo parameter to `fetchUserCommentsInRange()`

- **reports.js** (+19 lines)
  - Added `repo` parameter to `fetchUserCommentsInRange()`
  - Implemented conditional filter: `repo:owner/repo` vs `org:organization`
  - Added `repo` parameter to `fetchAllCollaboratorsComments()`

- **tests/unit/reports.test.js** (+177 lines)
  - Added 6 comprehensive tests for repository filtering
  - Tests validate org-wide search, specific repo filtering, query construction
  - Tests verify special character handling and backward compatibility

### API Query Change

```javascript
// Before:
'org:' + org

// After:
repo ? 'repo:' + org + '/' + repo : 'org:' + org
```

## Impact

✅ **Benefits:**
- Reports now correctly show only hours from current repository
- Prevents confusion in multi-repo organizations
- Matches user expectations based on panel header display

✅ **Backward Compatibility:**
- Maintains org-wide search when repo parameter is not provided
- No breaking changes to existing functionality

## Test Coverage

✅ **All tests passing: 249/249**

**New test suites added:**
- `fetchUserCommentsInRange - Repository Filtering` (4 tests)
  - Org-wide search without repo parameter
  - Specific repository filtering with repo parameter
  - Complete query construction validation
  - Special character handling in repo names

- `fetchAllCollaboratorsComments - Repository Filtering` (2 tests)
  - Repo parameter propagation
  - Fallback to org-wide search

## Screenshots

_See issue #21 for visual demonstration of the bug_

## Checklist

- [x] Code implemented and tested
- [x] Unit tests added (6 new tests)
- [x] All tests passing (249/249)
- [x] Backward compatibility maintained
- [x] Documentation updated (JSDoc comments)
- [x] No breaking changes

## Related Issues

Fixes #21

---

**Reviewers:** Please verify that reports now correctly filter by the repository shown in the panel header.

**Co-Authored-By:** Gopenux AI Team <ai@gopenux.com>