### PR TITLE
docs: update README version badge to v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Track time effortlessly. Generate reports instantly. Your data stays yours.**
 
-[![Version](https://img.shields.io/badge/Version-1.2.1-brightgreen?style=for-the-badge&logo=git&logoColor=white)](https://github.com/Gopenux/CronoHub/releases)
+[![Version](https://img.shields.io/badge/Version-1.3.0-brightgreen?style=for-the-badge&logo=git&logoColor=white)](https://github.com/Gopenux/CronoHub/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 [![Chrome Extension](https://img.shields.io/badge/Chrome-Extension-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white)](https://www.google.com/chrome/)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-green?style=for-the-badge&logo=google&logoColor=white)](https://developer.chrome.com/docs/extensions/mv3/)


### PR DESCRIPTION
## Summary
- Updated version badge in README.md from 1.2.1 to 1.3.0 to match manifest.json

## Related Issue
Fixes #35

## Test plan
- Version badge now displays v1.3.0
- Badge link points to releases page
- All other README content unchanged