### PR TITLE
fix: Remove unnecessary activeTab permission (v1.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Track time effortlessly. Generate reports instantly. Your data stays yours.**
 
-[![Version](https://img.shields.io/badge/Version-1.3.0-brightgreen?style=for-the-badge&logo=git&logoColor=white)](https://github.com/Gopenux/CronoHub/releases)
+[![Version](https://img.shields.io/badge/Version-1.3.1-brightgreen?style=for-the-badge&logo=git&logoColor=white)](https://github.com/Gopenux/CronoHub/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 [![Chrome Extension](https://img.shields.io/badge/Chrome-Extension-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white)](https://www.google.com/chrome/)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-green?style=for-the-badge&logo=google&logoColor=white)](https://developer.chrome.com/docs/extensions/mv3/)

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,14 @@
 {
   "manifest_version": 3,
   "name": "CronoHub",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Track time on GitHub issues. Register worked hours directly in comments with automatic formatting. By Gopenux AI.",
   "author": "Gopenux AI - Gopenux Lab",
   "background": {
     "service_worker": "background.js"
   },
   "permissions": [
-    "storage",
-    "activeTab"
+    "storage"
   ],
   "host_permissions": [
     "https://github.com/*",

--- a/tests/e2e/extension-structure.test.js
+++ b/tests/e2e/extension-structure.test.js
@@ -117,7 +117,7 @@ describe('Extension Structure E2E Tests', () => {
 
     const manifest = await response.json();
     expect(manifest.name).toBe('CronoHub');
-    expect(manifest.version).toBe('1.3.0');
+    expect(manifest.version).toBe('1.3.1');
     expect(manifest.manifest_version).toBe(3);
   });
 

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -41,7 +41,8 @@ describe('Manifest V3 Validation', () => {
 
   test('should have necessary permissions', () => {
     expect(manifest.permissions).toContain('storage');
-    expect(manifest.permissions).toContain('activeTab');
+    // activeTab is not needed - content scripts are injected declaratively
+    expect(manifest.permissions).not.toContain('activeTab');
   });
 
   test('should have host_permissions for GitHub', () => {


### PR DESCRIPTION
## Summary

Removes the unnecessary `activeTab` permission from `manifest.json` and bumps version to `1.3.1`.

## Changes

- ✅ Removed `"activeTab"` from permissions array in `manifest.json`
- ✅ Updated version from `1.3.0` to `1.3.1`
- ✅ Updated version badge in `README.md`

## Analysis

After thorough code review, the extension does not use any Chrome APIs that require the `activeTab` permission:

- ❌ No `chrome.tabs.*` API usage
- ❌ No `chrome.scripting.executeScript()` for dynamic injection
- ❌ No `chrome.tabs.captureVisibleTab()` for screenshots
- ❌ No programmatic tab access

The content scripts are injected **declaratively** through the manifest's `content_scripts` section, which does not require `activeTab`.

## Current Permissions

After this change, the extension only requires:

- ✅ `storage` - For token and user data storage
- ✅ `host_permissions` for `github.com` and `api.github.com` - For content script DOM access and API calls

## Benefits

1. **Better privacy** - Requests fewer unnecessary permissions
2. **Better security** - Follows principle of least privilege
3. **Better user perception** - Chrome Web Store will show fewer permission warnings
4. **No functional impact** - Extension will work exactly the same

## Test plan

- [x] Review code to confirm no `activeTab` API usage
- [ ] Load unpacked extension in Chrome with updated manifest
- [ ] Verify extension functionality (time logging and reports)
- [ ] Confirm no permission-related errors in console
- [ ] Test on both classic issues and GitHub Projects

Fixes #38

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)